### PR TITLE
Fix can_moderate not accounting for admin perms

### DIFF
--- a/toolbox/members.py
+++ b/toolbox/members.py
@@ -188,7 +188,12 @@ def can_moderate(
     if permissions is hikari.Permissions.NONE:
         return True
 
-    return bool(calculate_permissions(moderator) & permissions)
+    mod_perms = calculate_permissions(moderator)
+
+    if mod_perms & hikari.Permissions.ADMINISTRATOR:
+        return True
+
+    return bool(mod_perms & permissions)
 
 
 # MIT License


### PR DESCRIPTION
Fix `can_moderate` not accounting for the moderator having `hikari.Permissions.ADMINISTRATOR` and returning `False` in cases it shouldn't.

Closes #14 